### PR TITLE
Made NLL not create a new struct per loss function

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -16,9 +16,6 @@ pub fn main() !void {
     // Get MNIST data
     const mnist_data = try mnist.readMnist(&allocator);
 
-    // Prep loss function
-    const loss_function = nll.NLL(OUTPUT_SIZE);
-
     // Prep NN
     var layer1 = try layer.Layer(INPUT_SIZE, 100).init(&allocator);
     var relu1 = relu.Relu.new();
@@ -38,7 +35,7 @@ pub fn main() !void {
             const outputs1 = try layer1.forward(inputs, &allocator);
             const outputs2 = try relu1.forward(outputs1, &allocator);
             const outputs3 = try layer2.forward(outputs2, &allocator);
-            const loss = try loss_function.nll(outputs3, targets, &allocator);
+            const loss = try nll.nll(OUTPUT_SIZE, outputs3, targets, &allocator);
 
             // Update network
             const grads1 = try layer2.backwards(loss.input_grads, &allocator);
@@ -95,8 +92,6 @@ pub fn main() !void {
 test "Forward once" {
     var allocator = std.testing.allocator;
 
-    const loss_function = nll.NLL(2);
-
     // Create layer with custom weights
     var layer1 = try layer.Layer(2, 2).init(&allocator);
     allocator.free(layer1.weights);
@@ -121,7 +116,7 @@ test "Forward once" {
     // Test loss outputs
     var targets_array = [_]u8{ 0, 1 };
     const targets: []u8 = &targets_array;
-    const loss = try loss_function.nll(outputs, targets, &allocator);
+    const loss = try nll.nll(2, outputs, targets, &allocator);
     allocator.free(outputs);
     const expected_loss = [2]f64{ 0.7082596763414484, 0.658759555548697 };
     i = 0;
@@ -181,9 +176,6 @@ test "Train Memory Leak" {
     // Get MNIST data
     const mnist_data = try mnist.readMnist(&allocator);
 
-    // Prep loss function
-    const loss_function = nll.NLL(OUTPUT_SIZE);
-
     // Prep NN
     var layer1 = try layer.Layer(INPUT_SIZE, 100).init(&allocator);
     var relu1 = relu.Relu.new();
@@ -197,7 +189,7 @@ test "Train Memory Leak" {
     const outputs1 = try layer1.forward(inputs, &allocator);
     const outputs2 = try relu1.forward(outputs1, &allocator);
     const outputs3 = try layer2.forward(outputs2, &allocator);
-    const loss = try loss_function.nll(outputs3, targets, &allocator);
+    const loss = try nll.nll(OUTPUT_SIZE, outputs3, targets, &allocator);
 
     // Update network
     const grads1 = try layer2.backwards(loss.input_grads, &allocator);

--- a/src/nll.zig
+++ b/src/nll.zig
@@ -1,54 +1,46 @@
 const std = @import("std");
+const NLLOuput = struct {
+    loss: []f64,
+    input_grads: []f64,
+    const Self = @This();
 
-pub fn NLL(comptime I: usize) type {
-    const NLLOuput = struct {
-        loss: []f64,
-        input_grads: []f64,
-        const Self = @This();
+    pub fn destruct(self: Self, allocator: *std.mem.Allocator) void {
+        allocator.free(self.loss);
+        allocator.free(self.input_grads);
+    }
+};
 
-        pub fn destruct(self: Self, allocator: *std.mem.Allocator) void {
-            allocator.free(self.loss);
-            allocator.free(self.input_grads);
+pub fn nll(comptime I: usize, inputs: []f64, targets: []u8, allocator: *std.mem.Allocator) !NLLOuput {
+    const batch_size = targets.len;
+    var sum_e = try allocator.alloc(f64, batch_size);
+    defer allocator.free(sum_e);
+    var b: usize = 0;
+    while (b < batch_size) : (b += 1) {
+        var sum: f64 = 0;
+        var i: usize = 0;
+        while (i < I) : (i += 1) {
+            sum += std.math.exp(inputs[b * I + i]);
         }
-    };
+        sum_e[b] = sum;
+    }
 
-    return struct {
-        pub fn nll(inputs: []f64, targets: []u8, allocator: *std.mem.Allocator) !NLLOuput {
-            const batch_size = targets.len;
-            var sum_e = try allocator.alloc(f64, batch_size);
-            defer allocator.free(sum_e);
-            var b: usize = 0;
-            while (b < batch_size) : (b += 1) {
-                var sum: f64 = 0;
-                var i: usize = 0;
-                while (i < I): (i += 1) {
-                    sum += std.math.exp(inputs[b * I + i]);
-                }
-                sum_e[b] = sum;
+    var loss = try allocator.alloc(f64, batch_size);
+    b = 0;
+    while (b < batch_size) : (b += 1) {
+        loss[b] = -1 * std.math.ln(std.math.exp(inputs[b * I + targets[b]]) / sum_e[b]);
+    }
+
+    var input_grads = try allocator.alloc(f64, batch_size * I);
+    b = 0;
+    while (b < batch_size) : (b += 1) {
+        var i: usize = 0;
+        while (i < I) : (i += 1) {
+            input_grads[b * I + i] = std.math.exp(inputs[b * I + i]) / sum_e[b];
+            if (i == targets[b]) {
+                input_grads[b * I + i] -= 1;
             }
-
-            var loss = try allocator.alloc(f64, batch_size);
-            b = 0;
-            while (b < batch_size): (b += 1) {
-                loss[b] = -1 * std.math.ln(std.math.exp(inputs[b * I + targets[b]]) / sum_e[b]);
-            }
-
-            var input_grads = try allocator.alloc(f64, batch_size * I);
-            b = 0;
-            while (b < batch_size): (b += 1) {
-                var i: usize = 0;
-                while (i < I): (i += 1) {
-                    input_grads[b * I + i] = std.math.exp(inputs[b * I + i]) / sum_e[b];
-                    if (i == targets[b]) {
-                        input_grads[b * I + i] -= 1;
-                    }
-                }
-            }
-
-            return NLLOuput {
-                .loss = loss,
-                .input_grads = input_grads 
-            };
         }
-    };
+    }
+
+    return NLLOuput{ .loss = loss, .input_grads = input_grads };
 }


### PR DESCRIPTION
Now just uses a comptime parameter in the nll function, removing the intermediate struct.