### PR TITLE
Made allocators be passed by value

### DIFF
--- a/src/layer.zig
+++ b/src/layer.zig
@@ -1,12 +1,12 @@
 const std = @import("std");
 
 pub fn Layer(comptime I: usize, comptime O: usize) type {
-    const LayerGrads = struct { 
-        weight_grads: []f64, 
+    const LayerGrads = struct {
+        weight_grads: []f64,
         input_grads: []f64,
         const Self = @This();
 
-        pub fn destruct(self: Self, allocator: *std.mem.Allocator) void {
+        pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
             allocator.free(self.weight_grads);
             allocator.free(self.input_grads);
         }
@@ -19,7 +19,7 @@ pub fn Layer(comptime I: usize, comptime O: usize) type {
         last_inputs: []f64,
         const Self = @This();
 
-        pub fn forward(self: *Self, inputs: []f64, allocator: *std.mem.Allocator) ![]f64 {
+        pub fn forward(self: *Self, inputs: []f64, allocator: std.mem.Allocator) ![]f64 {
             const batch_size = inputs.len / I;
             var outputs = try allocator.alloc(f64, batch_size * O);
             var b: usize = 0;
@@ -38,7 +38,7 @@ pub fn Layer(comptime I: usize, comptime O: usize) type {
             return outputs;
         }
 
-        pub fn backwards(self: *Self, grads: []f64, allocator: *std.mem.Allocator) !LayerGrads {
+        pub fn backwards(self: *Self, grads: []f64, allocator: std.mem.Allocator) !LayerGrads {
             var weight_grads = try allocator.alloc(f64, I * O);
 
             const batch_size = self.last_inputs.len / I;
@@ -60,12 +60,12 @@ pub fn Layer(comptime I: usize, comptime O: usize) type {
 
         pub fn applyGradients(self: *Self, grads: []f64) void {
             var i: usize = 0;
-            while (i < I * O): (i += 1) {
+            while (i < I * O) : (i += 1) {
                 self.weights[i] -= 0.01 * grads[i];
             }
         }
 
-        pub fn init(allocator: *std.mem.Allocator) !Self {
+        pub fn init(allocator: std.mem.Allocator) !Self {
             var memory = try allocator.alloc(f64, I * O);
             var weights = memory[0 .. I * O];
             var prng = std.rand.DefaultPrng.init(123);
@@ -81,7 +81,7 @@ pub fn Layer(comptime I: usize, comptime O: usize) type {
             };
         }
 
-        pub fn destruct(self: *Self, allocator: *std.mem.Allocator) void {
+        pub fn deinit(self: *Self, allocator: std.mem.Allocator) void {
             allocator.free(self.weights);
         }
     };

--- a/src/mnist.zig
+++ b/src/mnist.zig
@@ -1,6 +1,5 @@
 const std = @import("std");
 
-
 const Data = struct {
     train_images: []f64,
     train_labels: []u8,
@@ -8,7 +7,7 @@ const Data = struct {
     test_labels: []u8,
     const Self = @This();
 
-    pub fn destruct(self: Self, allocator: *std.mem.Allocator) void {
+    pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
         allocator.free(self.train_images);
         allocator.free(self.train_labels);
         allocator.free(self.test_images);
@@ -16,14 +15,13 @@ const Data = struct {
     }
 };
 
-
-pub fn readMnist(allocator: *std.mem.Allocator) !Data {
+pub fn readMnist(allocator: std.mem.Allocator) !Data {
     const train_images_path: []const u8 = "data/train-images-idx3-ubyte";
     const train_images_u8 = try readIdxFile(train_images_path, 16, allocator);
     defer allocator.free(train_images_u8);
     var train_images = try allocator.alloc(f64, 784 * 60000);
     var i: u32 = 0;
-    while (i < 784 * 60000): (i += 1) {
+    while (i < 784 * 60000) : (i += 1) {
         const x: f64 = @intToFloat(f64, train_images_u8[i]);
         train_images[i] = x / 255;
     }
@@ -36,7 +34,7 @@ pub fn readMnist(allocator: *std.mem.Allocator) !Data {
     defer allocator.free(test_images_u8);
     var test_images = try allocator.alloc(f64, 784 * 10000);
     i = 0;
-    while (i < 784 * 10000): (i += 1) {
+    while (i < 784 * 10000) : (i += 1) {
         const x: f64 = @intToFloat(f64, test_images_u8[i]);
         test_images[i] = x / 255;
     }
@@ -44,17 +42,10 @@ pub fn readMnist(allocator: *std.mem.Allocator) !Data {
     const test_labels_path: []const u8 = "data/t10k-labels-idx1-ubyte";
     const test_labels = try readIdxFile(test_labels_path, 8, allocator);
 
-    return Data {
-        .train_images = train_images,
-        .train_labels = train_labels,
-        .test_images = test_images,
-        .test_labels = test_labels
-    };
-
-
+    return Data{ .train_images = train_images, .train_labels = train_labels, .test_images = test_images, .test_labels = test_labels };
 }
 
-pub fn readIdxFile(path: []const u8, skip_bytes: u8, allocator: *std.mem.Allocator) ![]u8 {
+pub fn readIdxFile(path: []const u8, skip_bytes: u8, allocator: std.mem.Allocator) ![]u8 {
     const file = try std.fs.cwd().openFile(
         path,
         .{},
@@ -64,7 +55,7 @@ pub fn readIdxFile(path: []const u8, skip_bytes: u8, allocator: *std.mem.Allocat
     const reader = file.reader();
     try reader.skipBytes(skip_bytes, .{});
     const data = reader.readAllAlloc(
-        allocator.*,
+        allocator,
         1000000000,
     );
     return data;

--- a/src/nll.zig
+++ b/src/nll.zig
@@ -6,14 +6,14 @@ pub fn NLL(comptime I: usize) type {
         input_grads: []f64,
         const Self = @This();
 
-        pub fn destruct(self: Self, allocator: *std.mem.Allocator) void {
+        pub fn deinit(self: Self, allocator: std.mem.Allocator) void {
             allocator.free(self.loss);
             allocator.free(self.input_grads);
         }
     };
 
     return struct {
-        pub fn nll(inputs: []f64, targets: []u8, allocator: *std.mem.Allocator) !NLLOuput {
+        pub fn nll(inputs: []f64, targets: []u8, allocator: std.mem.Allocator) !NLLOuput {
             const batch_size = targets.len;
             var sum_e = try allocator.alloc(f64, batch_size);
             defer allocator.free(sum_e);
@@ -21,7 +21,7 @@ pub fn NLL(comptime I: usize) type {
             while (b < batch_size) : (b += 1) {
                 var sum: f64 = 0;
                 var i: usize = 0;
-                while (i < I): (i += 1) {
+                while (i < I) : (i += 1) {
                     sum += std.math.exp(inputs[b * I + i]);
                 }
                 sum_e[b] = sum;
@@ -29,15 +29,15 @@ pub fn NLL(comptime I: usize) type {
 
             var loss = try allocator.alloc(f64, batch_size);
             b = 0;
-            while (b < batch_size): (b += 1) {
+            while (b < batch_size) : (b += 1) {
                 loss[b] = -1 * std.math.ln(std.math.exp(inputs[b * I + targets[b]]) / sum_e[b]);
             }
 
             var input_grads = try allocator.alloc(f64, batch_size * I);
             b = 0;
-            while (b < batch_size): (b += 1) {
+            while (b < batch_size) : (b += 1) {
                 var i: usize = 0;
-                while (i < I): (i += 1) {
+                while (i < I) : (i += 1) {
                     input_grads[b * I + i] = std.math.exp(inputs[b * I + i]) / sum_e[b];
                     if (i == targets[b]) {
                         input_grads[b * I + i] -= 1;
@@ -45,10 +45,7 @@ pub fn NLL(comptime I: usize) type {
                 }
             }
 
-            return NLLOuput {
-                .loss = loss,
-                .input_grads = input_grads 
-            };
+            return NLLOuput{ .loss = loss, .input_grads = input_grads };
         }
     };
 }

--- a/src/relu.zig
+++ b/src/relu.zig
@@ -5,15 +5,15 @@ pub const Relu = struct {
     const Self = @This();
 
     pub fn new() Self {
-        return Self {
+        return Self{
             .last_inputs = undefined,
         };
     }
 
-    pub fn forward(self: *Self, inputs: []f64, allocator: *std.mem.Allocator) ![]f64 {
+    pub fn forward(self: *Self, inputs: []f64, allocator: std.mem.Allocator) ![]f64 {
         var outputs = try allocator.alloc(f64, inputs.len);
         var i: usize = 0;
-        while (i < inputs.len): (i += 1) {
+        while (i < inputs.len) : (i += 1) {
             if (inputs[i] < 0) {
                 outputs[i] = 0.01 * inputs[i];
             } else {
@@ -24,10 +24,10 @@ pub const Relu = struct {
         return outputs;
     }
 
-    pub fn backwards(self: *Self, grads: []f64, allocator: *std.mem.Allocator) ![]f64 {
+    pub fn backwards(self: *Self, grads: []f64, allocator: std.mem.Allocator) ![]f64 {
         var outputs = try allocator.alloc(f64, grads.len);
         var i: usize = 0;
-        while (i < self.last_inputs.len): (i += 1) {
+        while (i < self.last_inputs.len) : (i += 1) {
             if (self.last_inputs[i] < 0) {
                 grads[i] = 0.01 * grads[i];
             } else {


### PR DESCRIPTION
Allocators are now passed around by value, as per https://github.com/ziglang/zig/issues/10052.
Also renamed destruct methods to deinit, as this is more idiomatic zig.
A general purpose allocator is now used, rather than a page allocator to avoid unnecessarily large allocations.