### PR TITLE
Use He weight initialization.

### DIFF
--- a/src/layer.zig
+++ b/src/layer.zig
@@ -71,7 +71,8 @@ pub fn Layer(comptime I: usize, comptime O: usize) type {
             var prng = std.rand.DefaultPrng.init(123);
             var w: usize = 0;
             while (w < I * O) : (w += 1) {
-                weights[w] = prng.random().floatNorm(f64) * 0.2;
+                const dev = @as(f64, @floatFromInt(I));
+                weights[w] = prng.random().floatNorm(f64) * @sqrt(2.0 / dev);
             }
             return Self{
                 .inputs = I,


### PR DESCRIPTION
this will allow you to go up to like 30 layers of depth with just this simple change, otherwise you will see vanishing gradients at only 5 layers.  see: https://docs.google.com/spreadsheets/d/1825onhH1uPmXJjqjOOZLDkHyJ_BaYP1LKGJzq5vDf4s/edit?usp=sharing sheet named "figure it out", has a comparison between the current (l5 a .0001) versus He init (l5 a0 He)